### PR TITLE
Add `Series.custom` to expose internals

### DIFF
--- a/src/gnuplot.ml
+++ b/src/gnuplot.ml
@@ -313,6 +313,8 @@ module Series = struct
     data : data;
   }
 
+  let custom cmd data = {cmd; data}
+
   let create ?title ?color ?weight ?fill kind data =
     let kind_text =
       match kind with

--- a/src/gnuplot.mli
+++ b/src/gnuplot.mli
@@ -95,6 +95,16 @@ module Labels : sig
   val create :  ?x:string -> ?y:string -> unit -> t
 end
 
+(** The representation of data-arrays (cf. the {!Series} module). *)
+type data =
+  | Data_Y of float list
+  | Data_XY of (float * float) list
+  | Data_TimeY of (time * float) list * timezone
+  | Data_DateY of (date * float) list
+  | Data_TimeOHLC of (time * (float * float * float * float)) list * timezone
+  | Data_DateOHLC of (date * (float * float * float * float)) list
+  | Func of string
+
 module Series : sig
   (** Represents a series of data for the plot functions in the [Gp] module. *)
   type t
@@ -306,6 +316,9 @@ module Series : sig
     -> ?fill:Filling.t
     -> (date * (float * float * float * float)) list
     -> t
+
+  (** Low-level, unsafe, interface, please see implementation. *)
+  val custom: string -> data -> t
 end
 
 (** {2 Main interface} *)


### PR DESCRIPTION
The same way there is a `?custom` argument in `plot_many`, this patch exposes the `Series` internals to be able to build more of them (while enjoying the proper wiring of the `data` part).

If you prefer keeping the API cleaner, no problem, just close this.

------------

So far I bypass the interface to add a `dashtype` (*color-blind-friendlyness*) with this gorgeous piece of poetry:

```ocaml
  module Hacked_series = struct
    [@@@ocaml.warning "-37"]

    type data =
      | Data_Y of float list
      | Data_XY of (float * float) list
      | Data_TimeY of (Gnuplot.time * float) list * Gnuplot.timezone
      | Data_DateY of (Gnuplot.date * float) list
      | Data_TimeOHLC of
          (Gnuplot.time * (float * float * float * float)) list
          * Gnuplot.timezone
      | Data_DateOHLC of (Gnuplot.date * (float * float * float * float)) list
      | Func of string

    type t = {cmd: string; data: data}

    let lines_xy ~title ~color:(`Rgb (r, g, b)) ~weight ~dashtype data =
      let cmd =
        String.concat ~sep:" "
          [ " '-' using 1:2 with lines"; Fmt.str "title \"%s\"" title
          ; Fmt.str "lw %d" (weight + if dashtype > 5 then 2 else 0)
          ; Fmt.str "lc rgb '#%02x%02x%02x'" r g b
          ; Fmt.str "dashtype %d" dashtype ] in
      let data = Data_XY data in
      ({cmd; data} |> Stdlib.Obj.magic : Gnuplot.Series.t)
  end
```

